### PR TITLE
DEV: Deploy static-redirect to fredjaya subdomain

### DIFF
--- a/global.R
+++ b/global.R
@@ -2,4 +2,4 @@ library(shiny)
 library(htmltools)
 library(markdown)
 library(rmarkdown)
-
+library(rsconnect)

--- a/renv.lock
+++ b/renv.lock
@@ -145,6 +145,16 @@
       ],
       "Hash": "33698c4b3127fc9f506654607fb73676"
     },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "3fd29944b231036ad67c3edb32e02201"
+    },
     "fastmap": {
       "Package": "fastmap",
       "Version": "1.2.0",
@@ -185,6 +195,17 @@
         "methods"
       ],
       "Hash": "5899f1eaa825580172bb56c08266f37c"
+    },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "xfun"
+      ],
+      "Hash": "d65ba49117ca223614f71b60d85b8ab7"
     },
     "htmltools": {
       "Package": "htmltools",
@@ -237,6 +258,22 @@
       ],
       "Hash": "4e993b65c2c3ffbffce7bb3e2c6f832b"
     },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.49",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "evaluate",
+        "highr",
+        "methods",
+        "tools",
+        "xfun",
+        "yaml"
+      ],
+      "Hash": "9fcb189926d93c636dea94fbe4f44480"
+    },
     "later": {
       "Package": "later",
       "Version": "1.3.2",
@@ -270,6 +307,19 @@
         "R"
       ],
       "Hash": "7ce2733a9826b3aeb1775d56fd305472"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "commonmark",
+        "utils",
+        "xfun"
+      ],
+      "Hash": "074efab766a9d6360865ad39512f2a7e"
     },
     "memoise": {
       "Package": "memoise",
@@ -360,6 +410,29 @@
         "utils"
       ],
       "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.29",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bslib",
+        "evaluate",
+        "fontawesome",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "knitr",
+        "methods",
+        "tinytex",
+        "tools",
+        "utils",
+        "xfun",
+        "yaml"
+      ],
+      "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
     "rsconnect": {
       "Package": "rsconnect",
@@ -455,6 +528,16 @@
       "Repository": "CRAN",
       "Hash": "de342ebfebdbf40477d0758d05426646"
     },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.54",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "xfun"
+      ],
+      "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
+    },
     "withr": {
       "Package": "withr",
       "Version": "3.0.2",
@@ -466,6 +549,19 @@
         "graphics"
       ],
       "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.49",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "stats",
+        "tools"
+      ],
+      "Hash": "8687398773806cfff9401a2feca96298"
     },
     "xtable": {
       "Package": "xtable",

--- a/rsconnect/shinyapps.io/fredjaya/pooltools.dcf
+++ b/rsconnect/shinyapps.io/fredjaya/pooltools.dcf
@@ -5,6 +5,6 @@ account: fredjaya
 server: shinyapps.io
 hostUrl: https://api.shinyapps.io/v1
 appId: 10880234
-bundleId: 8883132
+bundleId: 9481908
 url: https://fredjaya.shinyapps.io/pooltools/
 version: 1


### PR DESCRIPTION
https://fredjaya.shinyapps.io/pooltools/ now shows the static redirect #47

Had a similar issue to [this](https://stackoverflow.com/questions/77684393/how-to-solve-the-application-failed-to-start-exit-status-1-error-when-deployi) when deploying.

Adding `library(rsconnect)` and updating the renv lockfile seemed to fix it. 

Welcome to close PR if not relevant!